### PR TITLE
Refactor SQL query to use parameterized values

### DIFF
--- a/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/1608_133551544215490435/values.xml
+++ b/.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/1608_133551544215490435/values.xml
@@ -1,0 +1,3 @@
+﻿<values>
+  <value name="StillAlive" type="qword">133551547404819109</value>
+</values>

--- a/Ghas/Data/Repository.cs
+++ b/Ghas/Data/Repository.cs
@@ -89,9 +89,13 @@ public class Repository(IConfiguration configuration) : IRepository
         connection.Open();
 
         using var command = new SqlCommand(
-            $"UPDATE Persons SET Name = '{person.Name}', Age = {person.Age}, Description = '{person.Description}' " +
-            $"WHERE Id = '{person.Id}'",
+            "UPDATE Persons SET Name = @Name, Age = @Age, Description = @Description WHERE Id = @Id",
             connection);
+
+        command.Parameters.AddWithValue("@Name", person.Name);
+        command.Parameters.AddWithValue("@Age", person.Age);
+        command.Parameters.AddWithValue("@Description", person.Description);
+        command.Parameters.AddWithValue("@Id", person.Id);
 
         command.ExecuteNonQuery();
     }


### PR DESCRIPTION
This pull request includes changes that enhance the security of the software and update the registry. The most significant changes are the introduction of parameterized queries in the `UpdatePerson` method to prevent SQL injection attacks and an update to the `values.xml` file in the registry.

Security Enhancements:

* [`Ghas/Data/Repository.cs`](diffhunk://#diff-c417d19ec98ae6e2ad332813d98a4735736c4f3e3e6bf3703df349875a308016L92-R99): The `UpdatePerson` method has been modified to use parameterized queries. This helps prevent SQL injection attacks by ensuring that all input is treated as literal content and not part of the SQL command.

Registry Updates:

* [`.mono/registry/CurrentUser/software/microsoft/csdevkit/v1/pids/1608_133551544215490435/values.xml`](diffhunk://#diff-e1881ea5e00dc1c0e2104d1a1c18bde9f97eb6f763f1753e1fca59fd7190ae92R1-R3): The `StillAlive` value has been added to the registry, which could be used for various purposes such as checking the system's uptime or the application's running status.